### PR TITLE
0.4.x - Update PSR7 composer packages and add PHP 8.2 to gitlab workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,6 +25,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
 
     steps:
       - name: "Checkout"
@@ -108,6 +109,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         deps:
           - "lowest"
           - "latest"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ext-json": "*",
         "php-http/discovery": "^1.7",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || 2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "spomky-labs/base64url": "^2.0.1",
         "symfony/polyfill-mbstring": "^1.15",
@@ -62,7 +62,7 @@
     "require-dev": {
         "facile-it/facile-coding-standard": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "laminas/laminas-diactoros": "^2.2",
+        "laminas/laminas-diactoros": "^2.2 || ^3.0.0",
         "php-http/curl-client": "^2.1",
         "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
         "phpunit/phpunit": "^8.5.14 || ^9.3",

--- a/src/AbstractTokenVerifierBuilder.php
+++ b/src/AbstractTokenVerifierBuilder.php
@@ -14,20 +14,25 @@ use Facile\JoseVerifier\JWK\MemoryJwksProvider;
 /**
  * @psalm-import-type ClientMetadataObject from Psalm\PsalmTypes
  * @psalm-import-type JWKSetObject from Psalm\PsalmTypes
+ *
  * @psalm-type IssuerMetadataObject = array{issuer: string, jwks_uri: string}
+ *
  * @template TVerifier of AbstractTokenVerifier
+ *
  * @template-implements TokenVerifierBuilderInterface<TVerifier>
  */
 abstract class AbstractTokenVerifierBuilder implements TokenVerifierBuilderInterface
 {
     /**
      * @var null|array<string, mixed>
+     *
      * @psalm-var null|ClientMetadataObject
      */
     protected $clientMetadata;
 
     /**
      * @var null|array<string, mixed>
+     *
      * @psalm-var null|IssuerMetadataObject
      */
     protected $issuerMetadata;
@@ -49,6 +54,7 @@ abstract class AbstractTokenVerifierBuilder implements TokenVerifierBuilderInter
 
     /**
      * @param array<string, mixed> $clientMetadata
+     *
      * @psalm-param ClientMetadataObject $clientMetadata
      */
     public function setClientMetadata(array $clientMetadata): void
@@ -58,6 +64,7 @@ abstract class AbstractTokenVerifierBuilder implements TokenVerifierBuilderInter
 
     /**
      * @param array<string, mixed> $issuerMetadata
+     *
      * @psalm-param IssuerMetadataObject $issuerMetadata
      */
     public function setIssuerMetadata(array $issuerMetadata): void
@@ -133,6 +140,7 @@ abstract class AbstractTokenVerifierBuilder implements TokenVerifierBuilderInter
 
     /**
      * @return array<string, mixed>
+     *
      * @psalm-return ClientMetadataObject
      */
     protected function getClientMetadata(): array
@@ -146,6 +154,7 @@ abstract class AbstractTokenVerifierBuilder implements TokenVerifierBuilderInter
 
     /**
      * @return array<string, mixed>
+     *
      * @psalm-return IssuerMetadataObject
      */
     protected function getIssuerMetadata(): array

--- a/src/Checker/CallableChecker.php
+++ b/src/Checker/CallableChecker.php
@@ -19,6 +19,7 @@ final class CallableChecker implements ClaimChecker, HeaderChecker
 
     /**
      * @var callable
+     *
      * @psalm-var callable(mixed): bool
      */
     private $callable;

--- a/src/Decrypter/TokenDecrypter.php
+++ b/src/Decrypter/TokenDecrypter.php
@@ -150,6 +150,7 @@ class TokenDecrypter implements TokenDecrypterInterface
 
     /**
      * @return string[]
+     *
      * @psalm-return list<class-string<Algorithm>>
      */
     protected function getAlgorithmMap(): array

--- a/src/IdTokenVerifier.php
+++ b/src/IdTokenVerifier.php
@@ -61,6 +61,7 @@ final class IdTokenVerifier extends AbstractTokenVerifier implements IdTokenVeri
 
     /**
      * @inheritDoc
+     *
      * @psalm-suppress MixedReturnTypeCoercion
      */
     public function verify(string $jwt): array

--- a/src/JWK/JwksProviderBuilder.php
+++ b/src/JWK/JwksProviderBuilder.php
@@ -20,6 +20,7 @@ class JwksProviderBuilder
 {
     /**
      * @var array|null
+     *
      * @psalm-var null|JWKSetObject
      */
     private $jwks;

--- a/src/JWK/MemoryJwksProvider.php
+++ b/src/JWK/MemoryJwksProvider.php
@@ -11,6 +11,7 @@ class MemoryJwksProvider implements JwksProviderInterface
 {
     /**
      * @var array
+     *
      * @psalm-var JWKSetObject
      */
     private $jwks;

--- a/src/JWK/RemoteJwksProvider.php
+++ b/src/JWK/RemoteJwksProvider.php
@@ -45,8 +45,6 @@ class RemoteJwksProvider implements JwksProviderInterface
 
     /**
      * @param array<string, string|string[]> $headers
-     *
-     * @return RemoteJwksProvider
      */
     public function withHeaders(array $headers): self
     {
@@ -88,6 +86,7 @@ class RemoteJwksProvider implements JwksProviderInterface
 
     /**
      * @param mixed $data
+     *
      * @psalm-assert-if-true JWKSetObject $data
      */
     private function isJWKSet($data): bool

--- a/src/JWTVerifier.php
+++ b/src/JWTVerifier.php
@@ -10,6 +10,7 @@ final class JWTVerifier extends AbstractTokenVerifier
 {
     /**
      * @inheritDoc
+     *
      * @psalm-suppress MixedReturnTypeCoercion
      */
     public function verify(string $jwt): array

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -16,6 +16,7 @@ use SimpleXMLElement;
 
 /**
  * @internal
+ *
  * @codeCoverageIgnore
  */
 final class Plugin implements PluginEntryPointInterface

--- a/src/Psalm/PsalmTypes.php
+++ b/src/Psalm/PsalmTypes.php
@@ -6,6 +6,7 @@ namespace Facile\JoseVerifier\Psalm;
 
 /**
  * @internal
+ *
  * @psalm-type JWKObject = array{kty: "RSA"|"EC"|"oct"|string, use?: "sig"|"enc"|string, key_ops?: list<"sign"|"verify"|"encrypt"|"decrypt"|"wrapKey"|"unwrapKey"|"deriveKey"|"deriveBits"|string>, kid?: string, alg?: string, x5u?: string, x5c?: list<string>, x5t?: string, x5t#S256?: string, crv?: string, x?: string, y?: string, k?: string, n?: string, e?: string, d?: string, p?: string, q?: string, dp?: string, dq?: string, qi?: string}
  * @psalm-type JWKSetObject = array{keys: list<JWKObject>}
  * @psalm-type OpenIdDisplayType = non-empty-string

--- a/src/TokenVerifierBuilderInterface.php
+++ b/src/TokenVerifierBuilderInterface.php
@@ -8,6 +8,7 @@ use Facile\JoseVerifier\JWK\JwksProviderInterface;
 
 /**
  * @template TVerifier of TokenVerifierInterface
+ *
  * @psalm-import-type ClientMetadataObject from Psalm\PsalmTypes
  * @psalm-import-type IssuerMetadataObject from Psalm\PsalmTypes
  */
@@ -15,12 +16,14 @@ interface TokenVerifierBuilderInterface
 {
     /**
      * @param array<string, mixed> $clientMetadata
+     *
      * @psalm-param ClientMetadataObject $clientMetadata
      */
     public function setClientMetadata(array $clientMetadata): void;
 
     /**
      * @param array<string, mixed> $issuerMetadata
+     *
      * @psalm-param IssuerMetadataObject $issuerMetadata
      */
     public function setIssuerMetadata(array $issuerMetadata): void;

--- a/src/TokenVerifierInterface.php
+++ b/src/TokenVerifierInterface.php
@@ -27,6 +27,7 @@ interface TokenVerifierInterface
      * @throws InvalidTokenException
      *
      * @return array The JWT Payload
+     *
      * @psalm-return JWTPayloadObject
      */
     public function verify(string $jwt): array;

--- a/src/UserInfoVerifier.php
+++ b/src/UserInfoVerifier.php
@@ -10,6 +10,7 @@ final class UserInfoVerifier extends AbstractTokenVerifier
 {
     /**
      * @inheritDoc
+     *
      * @psalm-suppress MixedReturnTypeCoercion
      */
     public function verify(string $jwt): array

--- a/src/Validate/Validate.php
+++ b/src/Validate/Validate.php
@@ -88,7 +88,9 @@ final class Validate
 
     /**
      * @return string[]
+     *
      * @psalm-return list<class-string<Algorithm\SignatureAlgorithm>>
+     *
      * @psalm-suppress UndefinedClass
      * @psalm-suppress InvalidReturnStatement
      * @psalm-suppress InvalidReturnType


### PR DESCRIPTION
Hi,

We'd like to use the https://github.com/facile-it/php-openid-client package, but our project is dependent on newer versions of certain packages also used by this package.

To fix this, I have updated the 'psr/http-message' and 'laminas/laminas-diactoros' packages. I have also had to run cs-fix to pass the workflow checks. 

The workflow now also runs psalm and phpunit with PHP 8.2 as you can see here: https://github.com/belsimpel/php-jose-verifier/actions/runs/5667029591

It would be great if these changes could be merged and released as a 0.4.2 version.

I've also applied the same changes to the master branch in the companion MR 
https://github.com/facile-it/php-jose-verifier/pull/9