### PR TITLE
Update abandoned web-token dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "access token"
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "php-http/discovery": "^1.7",
         "psr/http-client": "^1.0",
@@ -40,11 +40,7 @@
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "spomky-labs/base64url": "^2.0.1",
         "symfony/polyfill-mbstring": "^1.15",
-        "web-token/jwt-checker": "^2.2.0 || ^3.0",
-        "web-token/jwt-core": "^2.2.0 || ^3.0",
-        "web-token/jwt-key-mgmt": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature-algorithm-rsa": "^2.2.0 || ^3.0"
+        "web-token/jwt-library": "^2.2.0 || ^3.0"
     },
     "autoload": {
         "files": [
@@ -68,23 +64,7 @@
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.6.3",
         "vimeo/psalm": "^5.6.0",
-        "web-token/jwt-encryption": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-aescbc": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-aesgcm": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-aesgcmkw": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-aeskw": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-dir": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-ecdh-es": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-experimental": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-pbes2": "^2.2.0 || ^3.0",
-        "web-token/jwt-encryption-algorithm-rsa": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature-algorithm-eddsa": "^2.2.0 || ^3.0",
-        "web-token/jwt-nested-token": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature-algorithm-ecdsa": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature-algorithm-experimental": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature-algorithm-hmac": "^2.2.0 || ^3.0",
-        "web-token/jwt-signature-algorithm-none": "^2.2.0 || ^3.0",
-        "web-token/jwt-util-ecc": "^2.2.0 || ^3.0"
+        "web-token/jwt-library": "^2.2.0 || ^3.0"
     },
     "scripts": {
         "cs-check": "php-cs-fixer fix --dry-run --diff --allow-risky=yes",


### PR DESCRIPTION
Fix warning about abandoned packages by replacing them with `web-token/jwt-library`

```
Package web-token/jwt-encryption is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-aescbc is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-aesgcm is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-aesgcmkw is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-aeskw is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-dir is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-ecdh-es is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-experimental is abandoned, you should avoid using it. Use web-token/jwt-experimental instead.
Package web-token/jwt-encryption-algorithm-pbes2 is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-encryption-algorithm-rsa is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-nested-token is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-signature-algorithm-ecdsa is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-signature-algorithm-eddsa is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-signature-algorithm-experimental is abandoned, you should avoid using it. Use web-token/jwt-experimental instead.
Package web-token/jwt-signature-algorithm-hmac is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-signature-algorithm-none is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-util-ecc is abandoned, you should avoid using it. Use web-token/jwt-library instead.
```

Note: `web-token/jwt-library[3.3.0, ..., 3.3.1] require php >=8.1` and PHP 8.0 would no longer be supported.