### PR TITLE
Update the `AbstractTokenVerifier` to pass the missing `$clock` parameter

### DIFF
--- a/src/AbstractTokenVerifier.php
+++ b/src/AbstractTokenVerifier.php
@@ -136,7 +136,7 @@ abstract class AbstractTokenVerifier implements TokenVerifierInterface
             ->withClaim(new IssuedAtChecker($this->clockTolerance, true, $this->clock))
             ->withClaim(new AudienceChecker($this->clientId, true))
             ->withClaim(new ExpirationTimeChecker($this->clockTolerance, false, $this->clock))
-            ->withClaim(new NotBeforeChecker($this->clockTolerance, true));
+            ->withClaim(new NotBeforeChecker($this->clockTolerance, true, $this->clock));
 
         if (null !== $this->expectedAzp) {
             $validator = $validator->withClaim(new AzpChecker($this->expectedAzp));


### PR DESCRIPTION
The `$clock` parameter will become required in `web-token/jwt-library` version `4.0.0`. This currently causes deprecation warnings (since version `3.3.0`).

Closes https://github.com/facile-it/php-jose-verifier/issues/27